### PR TITLE
reduce CPU usage from constant polling

### DIFF
--- a/plover_stenograph_usb.py
+++ b/plover_stenograph_usb.py
@@ -606,6 +606,7 @@ class Stenograph(ThreadedStenotypeBase):
                 if response.data_length and state.realtime:
                     for stroke in response.strokes():
                         self._on_stroke(stroke)
+                sleep(0.15)
 
         self._machine.disconnect()
 


### PR DESCRIPTION
On my computer, plover is one of the most resource intensive processes when using this plugin.
This is because the USB polling occurs in a loop with no sleep.
The code as it was, polled for USB information in excess of 1600 times a second.
This commit adds in a sleep to reduce that down to 6 to 7 polls a second.
A sleep of 0.15 seconds was chosen as this in excess of 5 strokes per second - the fastest I could find.
Additionally, the delay doesn't introduce significant lag to realtime output.