### PR TITLE
Change grouper call to explicitly specify fillvalue

### DIFF
--- a/plover_stenograph_usb.py
+++ b/plover_stenograph_usb.py
@@ -197,7 +197,7 @@ class StenoPacket:
         assert self.packet_id == self.ID_READ
 
         strokes = []
-        for stroke_data in grouper(8, self.data, 0):
+        for stroke_data in grouper(8, self.data, fillvalue=0):
             stroke = []
             # Get 4 bytes of steno, ignore timestamp.
             for steno_byte, key_chart_row in zip(stroke_data, STENO_KEY_CHART):


### PR DESCRIPTION
I'm very unfamiliar with python so I don't know when this changed or if its the best way to achieve this, but it makes the plugin work for me and one other person so far instead of getting an error from grouper and breaking the packets.